### PR TITLE
Added release joystick functionality in all 4 directions for left and…

### DIFF
--- a/Db/LogitechF710.db
+++ b/Db/LogitechF710.db
@@ -13,6 +13,8 @@ record(fanout, "$(P)$(R)LStickHorizontalFanout")
 {
 	field(LNK1, "$(P)$(R)LStickRight")
 	field(LNK2, "$(P)$(R)LStickLeft")
+	field(LNK3, "$(P)$(R)LStickRightHome")
+	field(LNK4, "$(P)$(R)LStickLeftHome")
 }
 
 record(calcout, "$(P)$(R)LStickRight")
@@ -26,6 +28,18 @@ record(calcout, "$(P)$(R)LStickRight")
 	field(OUT, "$(P)$(R)LSRightSeq.PROC")
 }
 
+record(calcout, "$(P)$(R)LStickRightHome")
+{
+        field(OOPT, "Transition To Zero")
+
+        field(INPA, "$(P)$(R)LStickHorizontal")
+
+        field(CALC, "((A - 127) > 50) ? 1 : 0")
+
+        field(OUT, "$(P)$(R)LSRightHomeSeq.PROC")
+}
+
+
 record(calcout, "$(P)$(R)LStickLeft")
 {
 	field(OOPT, "Transition To Non-zero")
@@ -37,6 +51,16 @@ record(calcout, "$(P)$(R)LStickLeft")
 	field(OUT, "$(P)$(R)LSLeftSeq.PROC")
 }
 
+record(calcout, "$(P)$(R)LStickLeftHome")
+{
+	field(OOPT, "Transition To Zero")
+
+	field(INPA, "$(P)$(R)LStickHorizontal")
+
+	field(CALC, "((A - 127) < -50) ? 1 : 0")
+	
+	field(OUT, "$(P)$(R)LSLeftHomeSeq.PROC")
+}
 
 record(ai, "$(P)$(R)LStickVertical")
 {
@@ -51,6 +75,8 @@ record(fanout, "$(P)$(R)LStickVerticalFanout")
 {
 	field(LNK1, "$(P)$(R)LStickUp")
 	field(LNK2, "$(P)$(R)LStickDown")
+	field(LNK3, "$(P)$(R)LStickUpHome")
+	field(LNK4, "$(P)$(R)LStickDownHome")
 }
 
 record(calcout, "$(P)$(R)LStickUp")
@@ -64,6 +90,17 @@ record(calcout, "$(P)$(R)LStickUp")
 	field(OUT, "$(P)$(R)LSUpSeq.PROC")
 }
 
+record(calcout, "$(P)$(R)LStickUpHome")
+{
+	field(OOPT, "Transition To Zero")
+
+	field(INPA, "$(P)$(R)LStickVertical")
+
+	field(CALC, "((A - 127) < -50) ? 1 : 0")
+	
+	field(OUT, "$(P)$(R)LSUpHomeSeq.PROC")
+}
+
 record(calcout, "$(P)$(R)LStickDown")
 {
 	field(OOPT, "Transition To Non-zero")
@@ -75,6 +112,16 @@ record(calcout, "$(P)$(R)LStickDown")
 	field(OUT, "$(P)$(R)LSDownSeq.PROC")
 }
 
+record(calcout, "$(P)$(R)LStickDownHome")
+{
+	field(OOPT, "Transition To Zero")
+
+	field(INPA, "$(P)$(R)LStickVertical")
+
+	field(CALC, "((A - 127) > 50) ? 1 : 0")
+	
+	field(OUT, "$(P)$(R)LSDownHomeSeq.PROC")
+}
 
 record(ai, "$(P)$(R)RStickHorizontal")
 {
@@ -91,6 +138,8 @@ record(fanout, "$(P)$(R)RStickHorizontalFanout")
 {
 	field(LNK1, "$(P)$(R)RStickRight")
 	field(LNK2, "$(P)$(R)RStickLeft")
+	field(LNK3, "$(P)$(R)RStickRightHome")
+	field(LNK4, "$(P)$(R)RStickLeftHome")
 }
 
 record(calcout, "$(P)$(R)RStickRight")
@@ -104,6 +153,17 @@ record(calcout, "$(P)$(R)RStickRight")
 	field(OUT, "$(P)$(R)RSRightSeq.PROC")
 }
 
+record(calcout, "$(P)$(R)RStickRightHome")
+{
+	field(OOPT, "Transition To Zero")
+
+	field(INPA, "$(P)$(R)RStickHorizontal")
+
+	field(CALC, "((A - 127) > 50) ? 1 : 0")
+	
+	field(OUT, "$(P)$(R)RSRightHomeSeq.PROC")
+}
+
 record(calcout, "$(P)$(R)RStickLeft")
 {
 	field(OOPT, "Transition To Non-zero")
@@ -115,6 +175,16 @@ record(calcout, "$(P)$(R)RStickLeft")
 	field(OUT, "$(P)$(R)RSLeftSeq.PROC")
 }
 
+record(calcout, "$(P)$(R)RStickLeftHome")
+{
+	field(OOPT, "Transition To Zero")
+
+	field(INPA, "$(P)$(R)RStickHorizontal")
+
+	field(CALC, "((A - 127) < -50) ? 1 : 0")
+	
+	field(OUT, "$(P)$(R)RSLeftHomeSeq.PROC")
+}
 
 record(ai, "$(P)$(R)RStickVertical")
 {
@@ -131,6 +201,8 @@ record(fanout, "$(P)$(R)RStickVerticalFanout")
 {
 	field(LNK1, "$(P)$(R)RStickUp")
 	field(LNK2, "$(P)$(R)RStickDown")
+	field(LNK3, "$(P)$(R)RStickUpHome")
+	field(LNK4, "$(P)$(R)RStickDownHome")
 }
 
 record(calcout, "$(P)$(R)RStickUp")
@@ -144,6 +216,17 @@ record(calcout, "$(P)$(R)RStickUp")
 	field(OUT, "$(P)$(R)RSUpSeq.PROC")
 }
 
+record(calcout, "$(P)$(R)RStickUpHome")
+{
+	field(OOPT, "Transition To Zero")
+
+	field(INPA, "$(P)$(R)RStickVertical")
+
+	field(CALC, "((A - 127) < -50) ? 1 : 0")
+	
+	field(OUT, "$(P)$(R)RSUpHomeSeq.PROC")
+}
+
 record(calcout, "$(P)$(R)RStickDown")
 {
 	field(OOPT, "Transition To Non-zero")
@@ -155,6 +238,16 @@ record(calcout, "$(P)$(R)RStickDown")
 	field(OUT, "$(P)$(R)RSDownSeq.PROC")
 }
 
+record(calcout, "$(P)$(R)RStickDownHome")
+{
+	field(OOPT, "Transition To Zero")
+
+	field(INPA, "$(P)$(R)RStickVertical")
+
+	field(CALC, "((A - 127) > 50) ? 1 : 0")
+	
+	field(OUT, "$(P)$(R)RSDownHomeSeq.PROC")
+}
 
 record(bi, "$(P)$(R)RightBumperPressed")
 {
@@ -510,12 +603,20 @@ record(seq, "$(P)$(R)RBSeq") {}
 record(seq, "$(P)$(R)RTSeq") {}
 record(seq, "$(P)$(R)R3Seq") {}
 record(seq, "$(P)$(R)LSUpSeq") {}
+record(seq, "$(P)$(R)LSUpHomeSeq") {}
 record(seq, "$(P)$(R)LSDownSeq") {}
+record(seq, "$(P)$(R)LSDownHomeSeq") {}
 record(seq, "$(P)$(R)LSLeftSeq") {}
+record(seq, "$(P)$(R)LSLeftHomeSeq"){}
 record(seq, "$(P)$(R)LSRightSeq") {}
+record(seq, "$(P)$(R)LSRightHomeSeq") {}
 record(seq, "$(P)$(R)RSUpSeq") {}
+record(seq, "$(P)$(R)RSUpHomeSeq") {}
 record(seq, "$(P)$(R)RSDownSeq") {}
+record(seq, "$(P)$(R)RSDownHomeSeq") {}
 record(seq, "$(P)$(R)RSLeftSeq") {}
+record(seq, "$(P)$(R)RSLeftHomeSeq") {}
 record(seq, "$(P)$(R)RSRightSeq") {}
+record(seq, "$(P)$(R)RSRightHomeSeq") {}
 record(seq, "$(P)$(R)StartSeq") {}
 record(seq, "$(P)$(R)BackSeq") {}

--- a/Db/LogitechF710_settings.req
+++ b/Db/LogitechF710_settings.req
@@ -24,3 +24,13 @@ file UserSeq.req P=$(P),R=$(R),SEQ=RTSeq
 file UserSeq.req P=$(P),R=$(R),SEQ=RBSeq
 file UserSeq.req P=$(P),R=$(R),SEQ=L3Seq
 file UserSeq.req P=$(P),R=$(R),SEQ=R3Seq
+
+file UserSeq.req P=$(P),R=$(R),SEQ=LSUpHomeSeq
+file UserSeq.req P=$(P),R=$(R),SEQ=LSDownHomeSeq
+file UserSeq.req P=$(P),R=$(R),SEQ=LSLeftHomeSeq
+file UserSeq.req P=$(P),R=$(R),SEQ=LSRightHomeSeq
+
+file UserSeq.req P=$(P),R=$(R),SEQ=RSUpHomeSeq
+file UserSeq.req P=$(P),R=$(R),SEQ=RSDownHomeSeq
+file UserSeq.req P=$(P),R=$(R),SEQ=RSLeftHomeSeq
+file UserSeq.req P=$(P),R=$(R),SEQ=RSRightHomeSeq


### PR DESCRIPTION
… right joysticks. Now  when you press joystick forward, the start sequence is executed(e.g. motor move) and when you release it,the stop sequence is executed (e.g. motor stop). When you press diagonally, one can control both motors at the same time with CA time precision.

This feature was added on a beamline request. They are having lots of fun and are moving two motors at the same time. I have created a new .opi screen, with this stop feature, and edited a main one. This will come in a separate PR. unfortunately translator works only one way. 

![StopSeqJoystick](https://user-images.githubusercontent.com/21367956/75276275-dca8fe00-57d3-11ea-9ce0-ff35b94d0764.png)
